### PR TITLE
Fix pronoun in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The paper is published in [Sensors Journal](https://www.mdpi.com/journal/sensors
 
 ### Please cite the paper if you use the code.
 
-If you have any questions, please post it in the [Discussions Section](https://github.com/ahmedHashwa/AirQuality-NARX-CNN-LSTM/discussions).
+If you have any questions, please post them in the [Discussions Section](https://github.com/ahmedHashwa/AirQuality-NARX-CNN-LSTM/discussions).
 
 To use the code you must use Python 3.8. 
 Download and install Graphviz from:  


### PR DESCRIPTION
## Summary
- pluralize the pronoun in README when mentioning questions

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6840ce4f8b2c8324bf47b30fd9decced