### PR TITLE
Fix Graphviz instructions for Codespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,13 @@ To use the code you must use Python 3.8.
 Download and install Graphviz from:  
 👉 https://graphviz.org/download/  
 Make sure to add the Graphviz bin directory to your PATH environment variable.  
-Install it before running the code.  
+Install it before running the code.
+If you are using GitHub Codespaces or a Debian-based Linux environment, you can
+install Graphviz with apt:
+
+```bash
+sudo apt-get update && sudo apt-get install -y graphviz
+```
 ### Requirements
 The libraries used in the code are:  
 tensorflow==2.13.0  


### PR DESCRIPTION
## Summary
- mention apt installation for Graphviz in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68415dc5e9e48324818d21cda96e2430